### PR TITLE
Support for numpy 1.24

### DIFF
--- a/XeprAPI/__init__.py
+++ b/XeprAPI/__init__.py
@@ -3,6 +3,7 @@
 # (c) Copyright 2014, Bruker BioSpin
 #
 # Modified by Sam Schott, University of Cambridge 2019.
+# Modified by Hugo Karas, ETH Zurich 2023.
 #
 
 from .main import (
@@ -11,5 +12,5 @@ from .main import (
 )
 
 
-__version__ = "0.61"
+__version__ = "0.61.1"
 __author__ = "Bruker Biospin"

--- a/XeprAPI/main.py
+++ b/XeprAPI/main.py
@@ -279,7 +279,7 @@ class Xepr(object):
             raise IOError('%sUnable to retrieve API function list' % _msgprefix)
         self._listoffunctions = ctypes.string_at(namesP).decode(_encoding).splitlines()
         self._listofargs = np.frombuffer(ctypes.string_at(argsP, numoffunctions), np.int8)
-        self._listofrets = np.frombuffer(ctypes.string_at(retsP, numoffunctions), np.bool)
+        self._listofrets = np.frombuffer(ctypes.string_at(retsP, numoffunctions), bool)
         prodeldirP = ctypes.c_char_p()
         self._API.XeprGetProDeLDir(byref(prodeldirP))
         prodeldoc = self._getprodelprototypes(ctypes.string_at(prodeldirP).decode(_encoding), PRODELDOCSUBDIR)
@@ -595,11 +595,11 @@ STACK_TYPES = (
     ctypes.c_long, ctypes.c_int, ctypes.c_short, char,
     str, Xepr.Xeprbuf,
 )
-INT_TYPES = frozenset((int, np.int, np.int32, np.int64))
+INT_TYPES = frozenset((int, np.int_, np.int32, np.int64))
 try:
-    FLOAT_TYPES = frozenset((float, np.float, np.float32, np.float64, np.float128))
+    FLOAT_TYPES = frozenset((float, np.double, np.float32, np.float64, np.float128))
 except AttributeError:
-    FLOAT_TYPES = frozenset((float, np.float, np.float32, np.float64))
+    FLOAT_TYPES = frozenset((float, np.double, np.float32, np.float64))
 
 
 class DatasetError(Exception):


### PR DESCRIPTION
Fixed issues detailed in [https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations) that were fully deprecated in version 1.24 breaking the package.

Mostly variables have been corrected to the numpy scalar type (e.g. `int ->` `np.int_`) with the exception of `np.bool` which has become `bool`. These should be identical as they were only ever aliases before.

Links with issue #2